### PR TITLE
Refactor IAM roles and policy attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.0.0] - 2026-04-28
+
+### Changed
+
+- BREAKING CHANGE: Refactored IAM roles and policies to create `admin` and `read-only`. These are AWS-wide and no longer limited to EKS access.
+
 ## [1.1.0] - 2026-03-12
 
 ### Added

--- a/eks.tf
+++ b/eks.tf
@@ -1,10 +1,10 @@
-resource "aws_eks_access_entry" "eks_admin" {
+resource "aws_eks_access_entry" "admin" {
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.admin.arn
   type          = "STANDARD"
 }
 
-resource "aws_eks_access_policy_association" "eks_admin" {
+resource "aws_eks_access_policy_association" "cluster_admin" {
   access_scope {
     type = "cluster"
   }
@@ -13,13 +13,13 @@ resource "aws_eks_access_policy_association" "eks_admin" {
   principal_arn = aws_iam_role.admin.arn
 }
 
-resource "aws_eks_access_entry" "eks_admin_view" {
+resource "aws_eks_access_entry" "read_only" {
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.read_only.arn
   type          = "STANDARD"
 }
 
-resource "aws_eks_access_policy_association" "eks_admin_view" {
+resource "aws_eks_access_policy_association" "admin_view" {
   access_scope {
     type = "cluster"
   }

--- a/eks.tf
+++ b/eks.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_access_entry" "eks_admin" {
   cluster_name  = var.cluster_name
-  principal_arn = aws_iam_role.eks_admin.arn
+  principal_arn = aws_iam_role.admin.arn
   type          = "STANDARD"
 }
 
@@ -10,12 +10,12 @@ resource "aws_eks_access_policy_association" "eks_admin" {
   }
   cluster_name  = var.cluster_name
   policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-  principal_arn = aws_iam_role.eks_admin.arn
+  principal_arn = aws_iam_role.admin.arn
 }
 
 resource "aws_eks_access_entry" "eks_admin_view" {
   cluster_name  = var.cluster_name
-  principal_arn = aws_iam_role.eks_admin_view.arn
+  principal_arn = aws_iam_role.read_only.arn
   type          = "STANDARD"
 }
 
@@ -25,5 +25,5 @@ resource "aws_eks_access_policy_association" "eks_admin_view" {
   }
   cluster_name  = var.cluster_name
   policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy"
-  principal_arn = aws_iam_role.eks_admin_view.arn
+  principal_arn = aws_iam_role.read_only.arn
 }

--- a/iam.tf
+++ b/iam.tf
@@ -14,37 +14,6 @@ resource "aws_iam_role" "admin" {
   name = "aerith-admin"
 }
 
-resource "aws_iam_role_policy" "admin" {
-  name = "aerith-admin"
-  role = aws_iam_role.admin.id
-
-  policy = jsonencode({
-    Statement = [
-      {
-        Action = [
-          "eks:AccessKubernetesApi",
-          "eks:DescribeAddon",
-          "eks:DescribeAddonVersions",
-          "eks:DescribeCluster",
-          "eks:DescribeFargateProfile",
-          "eks:DescribeIdentityProviderConfig",
-          "eks:DescribeNodegroup",
-          "eks:DescribeUpdate",
-          "eks:ListAddons",
-          "eks:ListClusters",
-          "eks:ListFargateProfiles",
-          "eks:ListIdentityProviderConfigs",
-          "eks:ListNodegroups",
-          "eks:ListUpdates",
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-    Version = "2012-10-17"
-  })
-}
-
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = aws_iam_role.admin.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -64,37 +33,6 @@ resource "aws_iam_role" "read_only" {
     Version = "2012-10-17"
   })
   name = aerith-read-only"
-}
-
-resource "aws_iam_role_policy" "read_only" {
-  name = "aerith-read-only"
-  role = aws_iam_role.read_only.id
-
-  policy = jsonencode({
-    Statement = [
-      {
-        Action = [
-          "eks:AccessKubernetesApi",
-          "eks:DescribeAddon",
-          "eks:DescribeAddonVersions",
-          "eks:DescribeCluster",
-          "eks:DescribeFargateProfile",
-          "eks:DescribeIdentityProviderConfig",
-          "eks:DescribeNodegroup",
-          "eks:DescribeUpdate",
-          "eks:ListAddons",
-          "eks:ListClusters",
-          "eks:ListFargateProfiles",
-          "eks:ListIdentityProviderConfigs",
-          "eks:ListNodegroups",
-          "eks:ListUpdates",
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-    Version = "2012-10-17"
-  })
 }
 
 resource "aws_iam_role_policy_attachment" "read_only" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,4 @@
-resource "aws_iam_role" "eks_admin" {
+resource "aws_iam_role" "admin" {
   assume_role_policy = jsonencode({
     Statement = [
       {
@@ -11,12 +11,12 @@ resource "aws_iam_role" "eks_admin" {
     ]
     Version = "2012-10-17"
   })
-  name = "aerith-eks-admin"
+  name = "aerith-admin"
 }
 
-resource "aws_iam_role_policy" "eks_admin" {
-  name = "eks-admin"
-  role = aws_iam_role.eks_admin.id
+resource "aws_iam_role_policy" "admin" {
+  name = "aerith-admin"
+  role = aws_iam_role.admin.id
 
   policy = jsonencode({
     Statement = [
@@ -45,7 +45,12 @@ resource "aws_iam_role_policy" "eks_admin" {
   })
 }
 
-resource "aws_iam_role" "eks_admin_view" {
+resource "aws_iam_role_policy_attachment" "admin" {
+  role       = aws_iam_role.admin.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role" "read_only" {
   assume_role_policy = jsonencode({
     Statement = [
       {
@@ -58,12 +63,12 @@ resource "aws_iam_role" "eks_admin_view" {
     ]
     Version = "2012-10-17"
   })
-  name = "aerith-eks-admin-view"
+  name = aerith-read-only"
 }
 
-resource "aws_iam_role_policy" "eks_admin_view" {
-  name = "eks-admin-view"
-  role = aws_iam_role.eks_admin_view.id
+resource "aws_iam_role_policy" "read_only" {
+  name = "aerith-read-only"
+  role = aws_iam_role.read_only.id
 
   policy = jsonencode({
     Statement = [
@@ -90,4 +95,9 @@ resource "aws_iam_role_policy" "eks_admin_view" {
     ]
     Version = "2012-10-17"
   })
+}
+
+resource "aws_iam_role_policy_attachment" "read_only" {
+  role       = aws_iam_role.read_only.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "read_only" {
     ]
     Version = "2012-10-17"
   })
-  name = aerith-read-only"
+  name = "aerith-read-only"
 }
 
 resource "aws_iam_role_policy_attachment" "read_only" {


### PR DESCRIPTION
This pull request updates the IAM role definitions in the `iam.tf` Terraform file to simplify role management and align with AWS managed policies. The changes primarily rename resources for clarity and replace custom inline policies with AWS managed policy attachments.

**IAM Role and Policy Management Improvements:**

* Renamed the `aws_iam_role` resource from `eks_admin` to `admin` and updated the role name from `aerith-eks-admin` to `aerith-admin` for clarity and broader use.
* Replaced the custom inline policy for the admin role with an attachment to the AWS managed `AdministratorAccess` policy, simplifying permissions management.
* Renamed the `aws_iam_role` resource from `eks_admin_view` to `read_only` and updated the role name from `aerith-eks-admin-view` to `aerith-read-only`.
* Replaced the custom inline policy for the read-only role with an attachment to the AWS managed `ReadOnlyAccess` policy, ensuring up-to-date and comprehensive read-only permissions.