### PR TITLE
feat: make EKS components optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:ycsDqsaBxoZmyx9tZKxOFinhpb0oDAGryioYuF1LvfA=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `enable_eks` variable to control the creation of EKS-related resources.
+- `add_eks_resources` variable to control the creation of EKS-related resources.
 
 ### Changed
 
 - Made `cluster_name` variable optional (defaults to `null`).
-- Made EKS access entries and policy associations optional, controlled by `enable_eks`.
+- Made EKS access entries and policy associations optional, controlled by `add_eks_resources`.
 
 ## [2.0.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Fixed
+- `enable_eks` variable to control the creation of EKS-related resources.
 
 ### Changed
 
-### Removed
+- Made `cluster_name` variable optional (defaults to `null`).
+- Made EKS access entries and policy associations optional, controlled by `enable_eks`.
 
 ## [2.0.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+### Removed
+
+## [2.1.0] - 2026-05-12
+
+### Added
+
 - `add_eks_resources` variable to control the creation of EKS-related resources.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Terraform Module Aerith AWS IAM
 
-This module creates IAM roles and EKS access entries for Aerith.
+This module creates IAM roles and optionally EKS access entries for Aerith.
 
 ## Resources
 
-- `aerith-eks-admin` IAM Role
-- `aerith-eks-admin-view` IAM Role
-- EKS Access Entry and Policy Association for `AmazonEKSClusterAdminPolicy`
-- EKS Access Entry and Policy Association for `AmazonEKSAdminViewPolicy`
+- `aerith-admin` IAM Role
+- `aerith-read-only` IAM Role
+- EKS Access Entry and Policy Association for `AmazonEKSClusterAdminPolicy` (Optional)
+- EKS Access Entry and Policy Association for `AmazonEKSAdminViewPolicy` (Optional)
 
 ## Usage
+
+### With EKS (Default)
 
 ```hcl
 module "aerith_iam" {
@@ -19,9 +21,20 @@ module "aerith_iam" {
 }
 ```
 
+### Without EKS
+
+```hcl
+module "aerith_iam" {
+  source = "github.com/footprint-it-solutions/terraform-module-aerith-aws-iam//?ref=main"
+
+  enable_eks = false
+}
+```
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster_name | The name of the EKS cluster | `string` | n/a | yes |
+| cluster_name | The name of the EKS cluster. Required if `enable_eks` is `true`. | `string` | `null` | no |
+| enable_eks | Whether to enable EKS-related resources. | `bool` | `true` | no |
 | trust_arn | The ARN of the IAM role to trust | `string` | `"arn:aws:iam::203918840229:role/aerith-gemini-cli"` | no |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "aerith_iam" {
 module "aerith_iam" {
   source = "github.com/footprint-it-solutions/terraform-module-aerith-aws-iam//?ref=main"
 
-  enable_eks = false
+  add_eks_resources = false
 }
 ```
 
@@ -35,6 +35,6 @@ module "aerith_iam" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster_name | The name of the EKS cluster. Required if `enable_eks` is `true`. | `string` | `null` | no |
-| enable_eks | Whether to enable EKS-related resources. | `bool` | `true` | no |
+| cluster_name | The name of the EKS cluster. Required if `add_eks_resources` is `true`. | `string` | `null` | no |
+| add_eks_resources | Whether to enable EKS-related resources. | `bool` | `true` | no |
 | trust_arn | The ARN of the IAM role to trust | `string` | `"arn:aws:iam::203918840229:role/aerith-gemini-cli"` | no |

--- a/eks.tf
+++ b/eks.tf
@@ -1,12 +1,12 @@
 resource "aws_eks_access_entry" "admin" {
-  count         = var.enable_eks ? 1 : 0
+  count         = var.add_eks_resources ? 1 : 0
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.admin.arn
   type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "cluster_admin" {
-  count = var.enable_eks ? 1 : 0
+  count = var.add_eks_resources ? 1 : 0
   access_scope {
     type = "cluster"
   }
@@ -16,14 +16,14 @@ resource "aws_eks_access_policy_association" "cluster_admin" {
 }
 
 resource "aws_eks_access_entry" "read_only" {
-  count         = var.enable_eks ? 1 : 0
+  count         = var.add_eks_resources ? 1 : 0
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.read_only.arn
   type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "admin_view" {
-  count = var.enable_eks ? 1 : 0
+  count = var.add_eks_resources ? 1 : 0
   access_scope {
     type = "cluster"
   }

--- a/eks.tf
+++ b/eks.tf
@@ -1,10 +1,12 @@
 resource "aws_eks_access_entry" "admin" {
+  count         = var.enable_eks ? 1 : 0
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.admin.arn
   type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "cluster_admin" {
+  count = var.enable_eks ? 1 : 0
   access_scope {
     type = "cluster"
   }
@@ -14,12 +16,14 @@ resource "aws_eks_access_policy_association" "cluster_admin" {
 }
 
 resource "aws_eks_access_entry" "read_only" {
+  count         = var.enable_eks ? 1 : 0
   cluster_name  = var.cluster_name
   principal_arn = aws_iam_role.read_only.arn
   type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "admin_view" {
+  count = var.enable_eks ? 1 : 0
   access_scope {
     type = "cluster"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,13 @@
 variable "cluster_name" {
+  default     = null
   description = "The name of the EKS cluster"
   type        = string
+}
+
+variable "enable_eks" {
+  default     = true
+  description = "Whether to enable EKS-related resources"
+  type        = bool
 }
 
 variable "trust_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {
   type        = string
 }
 
-variable "enable_eks" {
+variable "add_eks_resources" {
   default     = true
   description = "Whether to enable EKS-related resources"
   type        = bool


### PR DESCRIPTION
This PR was generated by Aerith.

**Slack Context:** https://footprint-it.slack.com/archives/C08PSC7ERL2/p1778594230013999

**Task ID:** make-eks-optional

**Changes:**
- Added `add_eks_resources` variable to control the creation of EKS-related resources.
- Made `cluster_name` variable optional (defaults to `null`).
- Made EKS access entries and policy associations optional, controlled by `add_eks_resources`.
- Updated README and CHANGELOG.
- Added `.gitignore`.
- Updated `.terraform.lock.hcl`.