### PR TITLE
Use correct AWS account ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.1.1] - 2026-05-13
+
+### Fixed
+
+- Use correct AWS account number is default value for trust_arn variable. 
+
 ## [2.1.0] - 2026-05-12
 
 ### Added

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "add_eks_resources" {
 }
 
 variable "trust_arn" {
-  default     = "arn:aws:iam::203918840229:role/aerith-gemini-cli"
+  default     = "arn:aws:iam::706124985648:role/aerith-gemini-cli"
   description = "The ARN of the IAM role to trust"
   type        = string
 }


### PR DESCRIPTION
This pull request updates the default value for the `trust_arn` variable in the `variables.tf` file. The new value points to a different AWS account and IAM role.

Configuration update:

* Changed the default value of `trust_arn` to use the ARN `arn:aws:iam::706124985648:role/aerith-gemini-cli`, replacing the previous account ID. (`variables.tf`)